### PR TITLE
docker login

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -374,7 +374,11 @@ Congratulations! You have successfully created your first docker image.
 What good is an application that can't be shared with friends, right? So in this section we are going to see how we can deploy our awesome application to the cloud so that we can share it with our friends! We're going to use AWS [Elastic Beanstalk](https://aws.amazon.com/elasticbeanstalk/) to get our application up and running in a few clicks. We'll also see how easy it is to make our application scalable and manageable with Beanstalk!
 
 ##### Docker push
-The first thing that we need to do before we deploy our app to AWS is to publish our image on a registry which can be accessed by AWS. There are many different [Docker registries](https://aws.amazon.com/ecr/) you can use (you can even host [your own](https://docs.docker.com/registry/deploying/)). For now, let's use [Docker Hub](https://hub.docker.com) to publish the image. To publish, just type
+The first thing that we need to do before we deploy our app to AWS is to publish our image on a registry which can be accessed by AWS. There are many different [Docker registries](https://aws.amazon.com/ecr/) you can use (you can even host [your own](https://docs.docker.com/registry/deploying/)). For now, let's use [Docker Hub](https://hub.docker.com) to publish the image. First log in to your Docker Hub account by typing
+```
+$ docker login
+```
+To publish, just type
 ```
 $ docker push prakhar1989/catnip
 ```


### PR DESCRIPTION
docker push doesn't work before running `docker login` first.

That is, `docker push` doesn't offer to log in, it just gives the error `denied: requested access to the resource is denied`.