### PR TITLE
Typo : 'bases' to 'officials'

### DIFF
--- a/tutorial/public/index.html
+++ b/tutorial/public/index.html
@@ -518,7 +518,7 @@ hello-world                     latest              0a6ba66e537a        11 weeks
 </ul>
 <p>Then there are official and user images, which can be both base and child images.</p>
 <ul>
-<li><p><strong>Official images</strong> are images that are officially maintained and supported by the folks at Docker. These are typically one word long. In the list of images above, the <code>python</code>, <code>ubuntu</code>, <code>busybox</code> and <code>hello-world</code> images are base images.</p>
+<li><p><strong>Official images</strong> are images that are officially maintained and supported by the folks at Docker. These are typically one word long. In the list of images above, the <code>python</code>, <code>ubuntu</code>, <code>busybox</code> and <code>hello-world</code> images are officials images.</p>
 </li>
 <li><p><strong>User images</strong> are images created and shared by users like you and me. They build on base images and add additional functionality. Typically, these are formatted as <code>user/image-name</code>.</p>
 </li>


### PR DESCRIPTION
A little typo in the section about `officials` and `bases` images