### PR TITLE
prettier code blocks

### DIFF
--- a/tutorial/layouts/partials/styles.html
+++ b/tutorial/layouts/partials/styles.html
@@ -65,17 +65,17 @@ hr { display: block; height: 2px; border: 0; border-top: 1px solid #aaa;border-b
 
 
 pre , code, kbd, samp {
-  color: #000;
-  font-family: monospace;
-  font-size: 1em;
+  color: #24292e;
+  font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 0.8em;
   border-radius:3px;
   background-color: #F8F8F8;
   border: 1px solid #CCC;
 }
 
-pre { padding: 5px 12px; overflow-x: auto; }
-pre code { border: 0px !important; padding: 0;}
-code { padding: 0 3px 0 3px; }
+code { padding: 0.1em 0.3em; }
+pre { font-size: inherit; padding: 0.5em 0.8em; margin: 1.2em 0; border: none !important; overflow: auto; }
+pre code { padding: 0; border: none !important; white-space: pre; }
 
 b, strong { font-weight: bold; }
 
@@ -166,132 +166,4 @@ table {
       margin-top: 0; }
     table tr th :last-child, table tr td :last-child {
       margin-bottom: 0; }
-</style><style>/*
-
-github.com style (c) Vasily Polovnyov <vast@whiteants.net>
-
-*/
-
-pre code {
-  display: block; padding: 0.5em;
-  color: #333;
-  background: #f8f8ff
-}
-
-pre .comment,
-pre .template_comment,
-pre .diff .header,
-pre .javadoc {
-  color: #998;
-  font-style: italic
-}
-
-pre .keyword,
-pre .css .rule .keyword,
-pre .winutils,
-pre .javascript .title,
-pre .nginx .title,
-pre .subst,
-pre .request,
-pre .status {
-  color: #333;
-  font-weight: bold
-}
-
-pre .number,
-pre .hexcolor,
-pre .ruby .constant {
-  color: #099;
-}
-
-pre .string,
-pre .tag .value,
-pre .phpdoc,
-pre .tex .formula {
-  color: #d14
-}
-
-pre .title,
-pre .id,
-pre .coffeescript .params,
-pre .scss .preprocessor {
-  color: #900;
-  font-weight: bold
-}
-
-pre .javascript .title,
-pre .lisp .title,
-pre .clojure .title,
-pre .subst {
-  font-weight: normal
-}
-
-pre .class .title,
-pre .haskell .type,
-pre .vhdl .literal,
-pre .tex .command {
-  color: #458;
-  font-weight: bold
-}
-
-pre .tag,
-pre .tag .title,
-pre .rules .property,
-pre .django .tag .keyword {
-  color: #000080;
-  font-weight: normal
-}
-
-pre .attribute,
-pre .variable,
-pre .lisp .body {
-  color: #008080
-}
-
-pre .regexp {
-  color: #009926
-}
-
-pre .class {
-  color: #458;
-  font-weight: bold
-}
-
-pre .symbol,
-pre .ruby .symbol .string,
-pre .lisp .keyword,
-pre .tex .special,
-pre .prompt {
-  color: #990073
-}
-
-pre .built_in,
-pre .lisp .title,
-pre .clojure .built_in {
-  color: #0086b3
-}
-
-pre .preprocessor,
-pre .pi,
-pre .doctype,
-pre .shebang,
-pre .cdata {
-  color: #999;
-  font-weight: bold
-}
-
-pre .deletion {
-  background: #fdd
-}
-
-pre .addition {
-  background: #dfd
-}
-
-pre .diff .change {
-  background: #0086b3
-}
-
-pre .chunk {
-  color: #aaa
-}</style>
+</style>


### PR DESCRIPTION
I have: 
- removed superfluous css code that was getting overridden later on (e.g `pre code{border...}`).
- removed GitHub styling code at the bottom because it did nothing to style the code blocks. A better option would be to add some styling library like prismjs or highlightjs (in case you don't want vanilla code blocks).
- made minor adjusts to make the code blocks look more like GitHub's without sacrificing the current styling/look.