### PR TITLE
Add missing command

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -803,10 +803,13 @@ ead0e804a67b        none                null                local
 
 The `network create` command creates a new *bridge* network, which is what we need at the moment. In terms of Docker, a bridge network uses a software bridge which allows containers connected to the same bridge network to communicate, while providing isolation from containers which are not connected to that bridge network. The Docker bridge driver automatically installs rules in the host machine so that containers on different bridge networks cannot communicate directly with each other. There are other kinds of networks that you can create, and you are encouraged to read about them in the official [docs](https://docs.docker.com/engine/userguide/networking/dockernetworks/).
 
-Now that we have a network, we can launch our containers inside this network using the `--net` flag. Let's do that - but first, we will stop our ES container that is running in the bridge (default) network.
+Now that we have a network, we can launch our containers inside this network using the `--net` flag. Let's do that - but first, we will stop and delete our ES container that is running in the bridge (default) network.
 
 ```bash
 $ docker container stop es
+es
+
+$ docker rm es
 es
 
 $ docker run -d --name es --net foodtrucks-net -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.3.2


### PR DESCRIPTION
The command 

```docker run -d --name es --net foodtrucks-net -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.3.2```

was throwing the following error:

```docker: Error response from daemon: Conflict. The container name "/es" is already in use by container "335f6ea596c831761a40c80db5019c147776dc41ea44c4f86d5446167526f0a5". You have to remove (or rename) that container to be able to reuse that name.```

The tutorial states the `es` container needs to be stopped before adding it to the foodtrucks-net network, but does not state that the container also needs to be deleted.

Solution is to delete the container before running the command to add the `es` container to the foodtrucks-net network by running:

`dcoker rm es` after running `docker container stop es`

Fixes issue reported in ticket #160 