### PR TITLE
Replace deprecated MAINTAINER instruction

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -631,7 +631,7 @@ Our [Dockerfile](https://github.com/prakhar1989/FoodTrucks/blob/master/Dockerfil
 # start from base
 FROM ubuntu:latest
 
-MAINTAINER Prakhar Srivastav <prakhar@prakhar.me>
+LABEL maintainer="Prakhar Srivastav <prakhar@prakhar.me>"
 
 # install system-wide deps for python and node
 RUN apt-get -yqq update


### PR DESCRIPTION
The MAINTAINER instruction has been deprecated in favour of LABEL.
(See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated).
Lets keep the tutorial up to date so newbies won't be encouraged to mimic
the old style.

_There is a corresponding to the PR in https://github.com/prakhar1989/FoodTrucks/pull/19_