### PR TITLE
Remove volumes in first compose yaml example

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -1023,8 +1023,6 @@ services:
       - es
     ports:
       - 5000:5000
-    volumes:
-      - ./flask-app:/opt/flask-app
 volumes:
   esdata1:
     driver: local


### PR DESCRIPTION
In the tutorial, you explain how to use local build instead of image and also running `grep hello app.py` which should return nothing. But it returns the code, because the volumes section is already there