### PR TITLE
Update index.md

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -662,14 +662,14 @@ Our [Dockerfile](https://github.com/prakhar1989/FoodTrucks/blob/master/Dockerfil
 
 ```dockerfile
 # start from base
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 MAINTAINER Prakhar Srivastav <prakhar@prakhar.me>
 
 # install system-wide deps for python and node
 RUN apt-get -yqq update
 RUN apt-get -yqq install python3-pip python3-dev curl gnupg
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
 RUN apt-get install -yq nodejs
 
 # copy our application code


### PR DESCRIPTION
Looks like MarkupSafe is yanked from ubuntu 18.04 base image. 
Updated to to a more recent version and also updated node version to a compatible one.

```bash
[+] Building 40.1s (16/16) FINISHED                                                                                          
 => [internal] load build definition from Dockerfile                                                                    0.0s
 => => transferring dockerfile: 687B                                                                                    0.0s
 => [internal] load .dockerignore                                                                                       0.0s
 => => transferring context: 2B                                                                                         0.0s
 => [internal] load metadata for docker.io/library/ubuntu:22.04                                                         0.6s
 => [ 1/11] FROM docker.io/library/ubuntu:22.04@sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68  0.0s
 => [internal] load build context                                                                                       0.0s
 => => transferring context: 2.76kB                                                                                     0.0s
 => CACHED [ 2/11] RUN apt-get -yqq update                                                                              0.0s
 => CACHED [ 3/11] RUN apt-get -yqq install python3-pip python3-dev curl gnupg                                          0.0s
 => [ 4/11] RUN curl -sL https://deb.nodesource.com/setup_16.x | bash                                                   4.8s
 => [ 5/11] RUN apt-get install -yq nodejs                                                                              7.0s 
 => [ 6/11] ADD flask-app /opt/flask-app                                                                                0.0s 
 => [ 7/11] WORKDIR /opt/flask-app                                                                                      0.0s 
 => [ 8/11] RUN npm install                                                                                            11.6s 
 => [ 9/11] RUN npm run build                                                                                          12.1s:
 => [10/11] RUN pip3 install -U MarkupSafe                                                                              0.7s 
 => [11/11] RUN pip3 install -r requirements.txt                                                                        1.9s 
 => exporting to image                                                                                                  1.1s 
 => => exporting layers                                                                                                 1.1s 
 => => writing image sha256:aecac6a447a52fc670e8968bb0b610a9789131cb6a5d2a17940549270ca176aa                            0.0s 
 => => naming to docker.io/sandylowe974/foodtrucks-web
```