### PR TITLE
Fix deprecated MAINTAINER in Dockerfile

### DIFF
--- a/tutorial/src/index.md
+++ b/tutorial/src/index.md
@@ -664,7 +664,7 @@ Our [Dockerfile](https://github.com/prakhar1989/FoodTrucks/blob/master/Dockerfil
 # start from base
 FROM ubuntu:18.04
 
-MAINTAINER Prakhar Srivastav <prakhar@prakhar.me>
+LABEL maintainer="Prakhar Srivastav <prakhar@prakhar.me>"
 
 # install system-wide deps for python and node
 RUN apt-get -yqq update


### PR DESCRIPTION
Fix the mismatch between the content on docker-curriculum and the source code

(https://github.com/prakhar1989/FoodTrucks/pull/19)