### PR TITLE
Update Flask version and add version requirement for Werkzeug

### DIFF
--- a/flask-app/requirements.txt
+++ b/flask-app/requirements.txt
@@ -1,1 +1,2 @@
-Flask==2.0.2
+Flask==3.0.0
+Werkzeug==3.0.0


### PR DESCRIPTION
Fixes error "Cannot import name 'url_quote' from 'werkzeug.urls'". 
Solution proposed by @dwolf42
Closes #378 