### PR TITLE
fix: Resolution du requirements avec la dependance flask

### DIFF
--- a/flask-app/requirements.txt
+++ b/flask-app/requirements.txt
@@ -1,1 +1,2 @@
 Flask==2.0.2
+werkzeug<2.1


### PR DESCRIPTION
Flask cannot run with werkzeug that is in newer version so that need to modify requirement and add older version for the werkzeug
<img width="1865" height="458" alt="Screenshot From 2025-08-07 20-22-06" src="https://github.com/user-attachments/assets/cf79d285-2619-47d8-9fba-0aa40b137883" />
